### PR TITLE
CI/release: Add back wildcard match for tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 on:
   push:
     tags:
+      - "*"
 
 name: Build & Release
 


### PR DESCRIPTION
While I've always thought that the wildcard was _not_ required if any tag is accepted, it does however make sure that GitHub does _not_ run on any branch push.  Right now it does so, because it probably sees an empty `tags:` object and considers that to be the same as an empty `push:` object.

As can be seen on the latest merge to `master`, the release workflow tried to run (but failed because there was no accompanying tag).

---

Apologies for the inconvenience, I learn something about GitHub CI every once in a while 😅
