### PR TITLE
Sort globals before output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -54,5 +54,7 @@ fn main() {
     };
     event_queue.roundtrip(&mut registry).unwrap();
 
+    registry.globals.sort_by(|g1, g2| g1.interface.cmp(&g2.interface));
+
     println!("{}", serde_json::to_string_pretty(&registry).unwrap());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,7 +54,9 @@ fn main() {
     };
     event_queue.roundtrip(&mut registry).unwrap();
 
-    registry.globals.sort_by(|g1, g2| g1.interface.cmp(&g2.interface));
+    registry
+        .globals
+        .sort_by(|g1, g2| g1.interface.cmp(&g2.interface));
 
     println!("{}", serde_json::to_string_pretty(&registry).unwrap());
 }


### PR DESCRIPTION
The order of the globals often changes, resulting in unneeded diffs. This change ensures the globals are sorted before output.