### PR TITLE
Add `--unique` to deduplicate interfaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wlprobe"
-version = "0.1.0"
+version = "0.0.3"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,17 +39,17 @@ impl Dispatch<wl_registry::WlRegistry, ()> for Registry {
 
 fn main() {
     let mut args = env::args().skip(1);
-    let mut dedup = false;
+    let mut unique = false;
     if let Some(arg) = args.next() {
         if args.next().is_some() {
             eprintln!("Too many arguments");
             process::exit(1);
         }
         match arg.as_str() {
-            "--dedup" => dedup = true,
+            "--unique" => unique = true,
             "--help" => {
                 eprintln!(
-                    "Options:\n\t--dedup\tKeep only one global per interface (highest version)"
+                    "Options:\n\t--unique\tKeep only one global per interface (highest version)"
                 );
                 process::exit(0);
             }
@@ -83,7 +83,7 @@ fn main() {
         .globals
         .sort_by(|g1, g2| g1.interface.cmp(&g2.interface));
 
-    if dedup {
+    if unique {
         let mut globals = Vec::new();
         mem::swap(&mut registry.globals, &mut globals);
         let mut iter = globals.drain(..);


### PR DESCRIPTION
I didn't add an argument parser because that seems overkill for a single argument (a single named argument is also positional :P). The deduplication turned out a bit ugly, `retain`/`retain_mut` doesn't work because we don't know if we want to retain because there might be another global with the same interface but a higher version, and I don't have other ideas.